### PR TITLE
changed vegalight to v4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name="vegascope",
       download_url = "https://raw.githubusercontent.com/scikit-hep/vegascope/master/vegascope.py",
       license = "BSD 3-clause",
       install_requires = [],
-      entry_points = {'altair.vegalite.v3.renderer': ['vegascope=vegascope:_vegalite_renderer_entry_point']},
+      entry_points = {'altair.vegalite.v4.renderer': ['vegascope=vegascope:_vegalite_renderer_entry_point']},
       classifiers = [
           "Development Status :: 5 - Production/Stable",
           "Intended Audience :: Developers",

--- a/vegascope.py
+++ b/vegascope.py
@@ -409,7 +409,7 @@ def _vegalite_renderer_entry_point(spec, embed_options=None):
         warnings.warn("embed_options is not yet supported & will be ignored")
 
     if _entrypoint_renderer_canvas is None:
-        _entrypoint_renderer_canvas = LocalCanvas(vega=altair.v3.VEGA_VERSION, vegalite=altair.v3.VEGALITE_VERSION, vegaembed=altair.v3.VEGAEMBED_VERSION)
+        _entrypoint_renderer_canvas = LocalCanvas(vega=altair.v4.VEGA_VERSION, vegalite=altair.v4.VEGALITE_VERSION, vegaembed=altair.v4.VEGAEMBED_VERSION)
 
     _entrypoint_renderer_canvas(spec)
     browser = _entrypoint_renderer_canvas.connection['browser']


### PR DESCRIPTION
Restores the ability to call `alt.renderers.enable('vegascope')` using packages `altair` 4.0.1 and `vega` 2.6.0. The error was:
```
NoSuchEntryPoint: No 'vegascope' entry point found in group 'altair.vegalite.v4.renderer'
```
See discussion on `vegascope` move to Vega-Lite 3: https://github.com/scikit-hep/vegascope/issues/5